### PR TITLE
Sorts bench recipes by required smithing level

### DIFF
--- a/plugins/skills/src/main/java/org/runetale/skills/page/SmeltingPage.java
+++ b/plugins/skills/src/main/java/org/runetale/skills/page/SmeltingPage.java
@@ -25,6 +25,7 @@ import org.runetale.skills.service.CraftingRecipeTagService;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -253,6 +254,9 @@ public class SmeltingPage extends AbstractTimedCraftingPage<SmeltingPage.Smeltin
 				}
 			}
 		}
+
+		filtered.sort(Comparator.comparingInt(recipe ->
+				CraftingPageSupport.getSmithingRequiredLevel(craftingRecipeTagService().getSkillRequirements(recipe))));
 
 		return filtered;
 	}

--- a/plugins/skills/src/main/java/org/runetale/skills/page/SmithingPage.java
+++ b/plugins/skills/src/main/java/org/runetale/skills/page/SmithingPage.java
@@ -24,6 +24,8 @@ import org.runetale.skills.service.CraftingPageTrackerService;
 import org.runetale.skills.service.CraftingRecipeTagService;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -110,8 +112,10 @@ public class SmithingPage extends AbstractTimedCraftingPage<SmithingPage.Smithin
 		commandBuilder.set("#SectionTitle.Text", selectedTier().getSectionTitle("Equipment"));
 
 		commandBuilder.clear("#RecipeGrid");
-		List<CraftingRecipe> recipes = CraftingPlugin.getBenchRecipes(
-				BenchType.Crafting, this.craftingConfig.anvilBenchId(), selectedTier().getAnvilCategory());
+		List<CraftingRecipe> recipes = new ArrayList<>(CraftingPlugin.getBenchRecipes(
+				BenchType.Crafting, this.craftingConfig.anvilBenchId(), selectedTier().getAnvilCategory()));
+		recipes.sort(Comparator.comparingInt(recipe ->
+				CraftingPageSupport.getSmithingRequiredLevel(craftingRecipeTagService().getSkillRequirements(recipe))));
 
 		for (int i = 0; i < recipes.size(); i++) {
 			CraftingRecipe recipe = recipes.get(i);


### PR DESCRIPTION
Ensures bench recipe lists are ordered by the smithing level required to craft them, improving discoverability and consistency in the UI. Converts recipe collections to modifiable lists and applies a comparator based on computed required level for both smithing and smelting displays.

This makes higher- and lower-level recipes appear in a predictable progression for users.
