### PR TITLE
Add configurable firemaking despawn modes for logs and campfires

### DIFF
--- a/plugins/skills-actions/src/main/java/org/runetale/skills/actions/ActionsSkillsPlugin.java
+++ b/plugins/skills-actions/src/main/java/org/runetale/skills/actions/ActionsSkillsPlugin.java
@@ -7,6 +7,7 @@ import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Int
 import org.runetale.skills.actions.config.ItemActionsExternalConfigBootstrap;
 import org.runetale.skills.actions.interaction.ConsumeSkillActionInteraction;
 import org.runetale.skills.actions.service.ItemActionPlacementQueueService;
+import org.runetale.skills.actions.system.ItemActionPlacementDespawnSystem;
 import org.runetale.skills.actions.system.ItemActionPendingPlacementSystem;
 import org.runetale.skills.api.SkillsRuntimeApi;
 import org.runetale.skills.api.SkillsRuntimeRegistry;
@@ -49,6 +50,9 @@ public class ActionsSkillsPlugin extends JavaPlugin {
         ItemActionsRuntimeRegistry.register(this.itemActionsConfig);
         ItemActionsRuntimeRegistry.registerPlacementQueueService(this.placementQueueService);
         this.getEntityStoreRegistry().registerSystem(new ItemActionPendingPlacementSystem(this.placementQueueService));
+        this.getEntityStoreRegistry().registerSystem(new ItemActionPlacementDespawnSystem(
+                this.placementQueueService,
+                this.itemActionsConfig));
 
         SkillsRuntimeApi runtimeApi = SkillsRuntimeRegistry.get();
         if (runtimeApi != null && this.itemActionsConfig != null && runtimeApi.isDebugEnabled(this.itemActionsConfig.debugPluginKey())) {

--- a/plugins/skills-actions/src/main/java/org/runetale/skills/actions/service/ItemActionPlacementQueueService.java
+++ b/plugins/skills-actions/src/main/java/org/runetale/skills/actions/service/ItemActionPlacementQueueService.java
@@ -1,5 +1,7 @@
 package org.runetale.skills.actions.service;
 
+import org.runetale.skills.config.ItemActionsConfig;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -19,6 +21,26 @@ public class ItemActionPlacementQueueService {
             @Nullable String expectedCurrentBlockId,
             @Nonnull String replacementBlockId,
             long applyAtMillis) {
+        queue(
+                worldName,
+                x,
+                y,
+                z,
+                expectedCurrentBlockId,
+                replacementBlockId,
+                ItemActionsConfig.BlockApplyMode.SET_BLOCK,
+                applyAtMillis);
+    }
+
+    public void queue(
+            @Nonnull String worldName,
+            int x,
+            int y,
+            int z,
+            @Nullable String expectedCurrentBlockId,
+            @Nullable String replacementBlockId,
+            @Nonnull ItemActionsConfig.BlockApplyMode applyMode,
+            long applyAtMillis) {
         BlockPositionKey key = new BlockPositionKey(worldName, x, y, z);
         this.placementsByPosition.put(
                 key,
@@ -26,6 +48,7 @@ public class ItemActionPlacementQueueService {
                         key,
                         expectedCurrentBlockId,
                         replacementBlockId,
+                        applyMode,
                         applyAtMillis));
     }
 
@@ -57,7 +80,13 @@ public class ItemActionPlacementQueueService {
     public record PendingPlacement(
             @Nonnull BlockPositionKey position,
             @Nullable String expectedCurrentBlockId,
-            @Nonnull String replacementBlockId,
+            @Nullable String replacementBlockId,
+            @Nonnull ItemActionsConfig.BlockApplyMode applyMode,
             long applyAtMillis) {
+
+        public PendingPlacement {
+            applyMode = applyMode == null ? ItemActionsConfig.BlockApplyMode.SET_BLOCK : applyMode;
+            replacementBlockId = replacementBlockId == null ? "" : replacementBlockId.trim();
+        }
     }
 }

--- a/plugins/skills-actions/src/main/java/org/runetale/skills/actions/system/ItemActionPendingPlacementSystem.java
+++ b/plugins/skills-actions/src/main/java/org/runetale/skills/actions/system/ItemActionPendingPlacementSystem.java
@@ -1,10 +1,22 @@
 package org.runetale.skills.actions.system;
 
 import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.system.DelayedSystem;
+import com.hypixel.hytale.math.util.ChunkUtil;
+import com.hypixel.hytale.math.vector.Vector3i;
 import com.hypixel.hytale.logger.HytaleLogger;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockBreakingDropType;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockGathering;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.HarvestingDropType;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.PhysicsDropType;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.SoftBlockDropType;
 import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockType;
+import com.hypixel.hytale.server.core.modules.interaction.BlockHarvestUtils;
 import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.chunk.BlockChunk;
+import com.hypixel.hytale.server.core.universe.world.chunk.section.BlockSection;
+import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import org.runetale.skills.actions.service.ItemActionPlacementQueueService;
 import org.runetale.skills.config.ItemActionsConfig;
@@ -41,21 +53,112 @@ public class ItemActionPendingPlacementSystem extends DelayedSystem<EntityStore>
                     continue;
                 }
 
-                world.setBlock(
-                        placement.position().x(),
-                        placement.position().y(),
-                        placement.position().z(),
-                        placement.replacementBlockId());
+                applyPlacement(store, world, placement);
             } catch (Exception exception) {
                 LOGGER.atWarning().withCause(exception).log(
-                        "[Skills Actions] Failed pending placement world=%s pos=%d,%d,%d block=%s",
+                        "[Skills Actions] Failed pending placement world=%s pos=%d,%d,%d mode=%s block=%s",
                         placement.position().worldName(),
                         placement.position().x(),
                         placement.position().y(),
                         placement.position().z(),
+                        placement.applyMode(),
                         placement.replacementBlockId());
             }
         }
+    }
+
+    private void applyPlacement(
+            @Nonnull Store<EntityStore> store,
+            @Nonnull World world,
+            @Nonnull ItemActionPlacementQueueService.PendingPlacement placement) {
+        if (placement.applyMode() == ItemActionsConfig.BlockApplyMode.NATURAL_REMOVE) {
+            applyNaturalRemoval(store, world, placement);
+            return;
+        }
+
+        String replacementBlockId = placement.replacementBlockId();
+        if (replacementBlockId == null || replacementBlockId.isBlank()) {
+            LOGGER.atWarning().log(
+                    "[Skills Actions] Skipped replacement due to blank set block id pos=%d,%d,%d",
+                    placement.position().x(),
+                    placement.position().y(),
+                    placement.position().z());
+            return;
+        }
+
+        world.setBlock(
+                placement.position().x(),
+                placement.position().y(),
+                placement.position().z(),
+                replacementBlockId);
+    }
+
+    private void applyNaturalRemoval(
+            @Nonnull Store<EntityStore> entityStore,
+            @Nonnull World world,
+            @Nonnull ItemActionPlacementQueueService.PendingPlacement placement) {
+        int x = placement.position().x();
+        int y = placement.position().y();
+        int z = placement.position().z();
+        BlockType currentBlockType = world.getBlockType(x, y, z);
+        if (currentBlockType == null) {
+            return;
+        }
+
+        Ref<ChunkStore> chunkReference = world.getChunkStore().getChunkReference(ChunkUtil.indexChunkFromBlock(x, z));
+        if (chunkReference == null || !chunkReference.isValid()) {
+            return;
+        }
+
+        Store<ChunkStore> chunkStore = world.getChunkStore().getStore();
+        if (chunkStore == null) {
+            return;
+        }
+
+        int filler = 0;
+        BlockChunk blockChunk = chunkStore.getComponent(chunkReference, BlockChunk.getComponentType());
+        if (blockChunk != null) {
+            BlockSection blockSection = blockChunk.getSectionAtBlockY(y);
+            filler = blockSection.getFiller(x, y, z);
+        }
+
+        int quantity = 1;
+        String itemId = null;
+        String dropListId = null;
+        BlockGathering blockGathering = currentBlockType.getGathering();
+        if (blockGathering != null) {
+            PhysicsDropType physics = blockGathering.getPhysics();
+            BlockBreakingDropType breaking = blockGathering.getBreaking();
+            SoftBlockDropType soft = blockGathering.getSoft();
+            HarvestingDropType harvest = blockGathering.getHarvest();
+            if (physics != null) {
+                itemId = physics.getItemId();
+                dropListId = physics.getDropListId();
+            } else if (breaking != null) {
+                quantity = breaking.getQuantity();
+                itemId = breaking.getItemId();
+                dropListId = breaking.getDropListId();
+            } else if (soft != null) {
+                itemId = soft.getItemId();
+                dropListId = soft.getDropListId();
+            } else if (harvest != null) {
+                itemId = harvest.getItemId();
+                dropListId = harvest.getDropListId();
+            }
+        }
+
+        int setBlockSettings = 256 | 32;
+        BlockHarvestUtils.naturallyRemoveBlock(
+                new Vector3i(x, y, z),
+                currentBlockType,
+                filler,
+                quantity,
+                itemId,
+                dropListId,
+                setBlockSettings,
+                chunkReference,
+                entityStore,
+                chunkStore);
     }
 
     private boolean targetStillMatches(

--- a/plugins/skills-actions/src/main/java/org/runetale/skills/actions/system/ItemActionPlacementDespawnSystem.java
+++ b/plugins/skills-actions/src/main/java/org/runetale/skills/actions/system/ItemActionPlacementDespawnSystem.java
@@ -1,0 +1,112 @@
+package org.runetale.skills.actions.system;
+
+import com.hypixel.hytale.component.ArchetypeChunk;
+import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.query.Query;
+import com.hypixel.hytale.component.system.EntityEventSystem;
+import com.hypixel.hytale.math.vector.Vector3i;
+import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockType;
+import com.hypixel.hytale.server.core.event.events.ecs.PlaceBlockEvent;
+import com.hypixel.hytale.server.core.inventory.ItemStack;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import org.runetale.skills.actions.service.ItemActionPlacementQueueService;
+import org.runetale.skills.config.ItemActionsConfig;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ItemActionPlacementDespawnSystem extends EntityEventSystem<EntityStore, PlaceBlockEvent> {
+
+    private final ItemActionPlacementQueueService placementQueueService;
+    private final ItemActionsConfig itemActionsConfig;
+    private final Query<EntityStore> query;
+
+    public ItemActionPlacementDespawnSystem(
+            @Nonnull ItemActionPlacementQueueService placementQueueService,
+            @Nonnull ItemActionsConfig itemActionsConfig) {
+        super(PlaceBlockEvent.class);
+        this.placementQueueService = placementQueueService;
+        this.itemActionsConfig = itemActionsConfig;
+        this.query = Query.and(PlayerRef.getComponentType());
+    }
+
+    @Override
+    public void handle(
+            int index,
+            @Nonnull ArchetypeChunk<EntityStore> archetypeChunk,
+            @Nonnull Store<EntityStore> store,
+            @Nonnull CommandBuffer<EntityStore> commandBuffer,
+            @Nonnull PlaceBlockEvent event) {
+        if (event.isCancelled() || this.itemActionsConfig.placementDespawnRules().isEmpty()) {
+            return;
+        }
+
+        Vector3i targetBlock = event.getTargetBlock();
+        String placedBlockId = resolvePlacedBlockId(event, store, targetBlock);
+        if (placedBlockId == null || placedBlockId.isBlank()) {
+            return;
+        }
+
+        ItemActionsConfig.PlacementDespawnRule matchedRule = matchRule(placedBlockId);
+        if (matchedRule == null || !matchedRule.hasDespawnAction()) {
+            return;
+        }
+
+        World world = store.getExternalData().getWorld();
+        String expectedBlockId = matchedRule.requireTargetBlockMatch()
+                ? placedBlockId
+                : null;
+        this.placementQueueService.queue(
+                world.getName(),
+                targetBlock.x,
+                targetBlock.y,
+                targetBlock.z,
+                expectedBlockId,
+                matchedRule.setBlockId(),
+                matchedRule.applyMode(),
+                System.currentTimeMillis() + matchedRule.delayMillis());
+    }
+
+    @Nonnull
+    @Override
+    public Query<EntityStore> getQuery() {
+        return this.query;
+    }
+
+    @Nullable
+    private ItemActionsConfig.PlacementDespawnRule matchRule(@Nonnull String blockId) {
+        for (ItemActionsConfig.PlacementDespawnRule rule : this.itemActionsConfig.placementDespawnRules()) {
+            if (!rule.enabled()) {
+                continue;
+            }
+            if (rule.matchesTargetBlockId(blockId)) {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String resolvePlacedBlockId(
+            @Nonnull PlaceBlockEvent event,
+            @Nonnull Store<EntityStore> store,
+            @Nonnull Vector3i targetBlock) {
+        ItemStack itemInHand = event.getItemInHand();
+        if (itemInHand != null) {
+            String blockKey = itemInHand.getBlockKey();
+            if (blockKey != null && !blockKey.isBlank()) {
+                return blockKey;
+            }
+        }
+
+        World world = store.getExternalData().getWorld();
+        BlockType currentBlockType = world.getBlockType(targetBlock.x, targetBlock.y, targetBlock.z);
+        if (currentBlockType == null) {
+            return null;
+        }
+        return currentBlockType.getId();
+    }
+}

--- a/plugins/skills-actions/src/main/resources/Skills/Config/item-actions.json
+++ b/plugins/skills-actions/src/main/resources/Skills/Config/item-actions.json
@@ -62,6 +62,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -81,6 +84,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -100,6 +106,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -119,6 +128,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -138,6 +150,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -157,6 +172,9 @@
       "targetBlockIds": [
         "RuneTale_Fire"
       ],
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -179,6 +197,9 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -201,6 +222,9 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -223,6 +247,9 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -245,6 +272,9 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -267,6 +297,9 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
@@ -289,10 +322,31 @@
       "replaceTargetBlockId": "RuneTale_Fire",
       "replaceTargetBlockDelayMillis": 0,
       "requireTargetBlockMatchForReplacement": true,
+      "despawnDelayMillis": 30000,
+      "despawnApplyMode": "NATURAL_REMOVE",
+      "requireTargetBlockMatchForDespawn": true,
       "trigger": {
         "mouseButton": "Right",
         "mouseState": "Pressed"
       }
+    }
+  ],
+  "placementDespawnRules": [
+    {
+      "id": "firemaking_placed_logs",
+      "enabled": true,
+      "targetBlockIds": [
+        "RuneTale_Log",
+        "RuneTale_Oak_Log",
+        "RuneTale_Willow_Log",
+        "RuneTale_Maple_Log",
+        "RuneTale_Yew_Log",
+        "RuneTale_Magic_Log"
+      ],
+      "delayMillis": 30000,
+      "applyMode": "SET_BLOCK",
+      "setBlockId": "Empty",
+      "requireTargetBlockMatch": true
     }
   ],
   "debug": {

--- a/plugins/skills-actions/src/test/java/org/runetale/skills/actions/service/ItemActionPlacementQueueServiceTest.java
+++ b/plugins/skills-actions/src/test/java/org/runetale/skills/actions/service/ItemActionPlacementQueueServiceTest.java
@@ -1,6 +1,7 @@
 package org.runetale.skills.actions.service;
 
 import org.junit.jupiter.api.Test;
+import org.runetale.skills.config.ItemActionsConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,5 +26,27 @@ class ItemActionPlacementQueueServiceTest {
         assertThat(service.pollDueForWorld("World_A", 2_000L)).isEmpty();
         assertThat(service.pollDueForWorld("World_A", 4_000L)).hasSize(1);
         assertThat(service.pollDueForWorld("World_B", 2_000L)).hasSize(1);
+    }
+
+    @Test
+    void queueSupportsNaturalRemoveApplyMode() {
+        ItemActionPlacementQueueService service = new ItemActionPlacementQueueService();
+        service.queue(
+                "World_A",
+                1,
+                64,
+                1,
+                "RuneTale_Fire",
+                "",
+                ItemActionsConfig.BlockApplyMode.NATURAL_REMOVE,
+                1_000L);
+
+        assertThat(service.pollDueForWorld("World_A", 2_000L))
+                .hasSize(1)
+                .first()
+                .satisfies(placement -> {
+                    assertThat(placement.applyMode()).isEqualTo(ItemActionsConfig.BlockApplyMode.NATURAL_REMOVE);
+                    assertThat(placement.replacementBlockId()).isBlank();
+                });
     }
 }

--- a/plugins/skills-actions/src/test/java/org/runetale/skills/config/ItemActionsConfigTest.java
+++ b/plugins/skills-actions/src/test/java/org/runetale/skills/config/ItemActionsConfigTest.java
@@ -55,6 +55,9 @@ class ItemActionsConfigTest {
                       "replaceTargetBlockId": "Furniture_Crude_Brazier",
                       "replaceTargetBlockDelayMillis": 1200,
                       "requireTargetBlockMatchForReplacement": false,
+                      "despawnDelayMillis": 30000,
+                      "despawnApplyMode": "NATURAL_REMOVE",
+                      "requireTargetBlockMatchForDespawn": false,
                       "trigger": {
                         "mouseButton": "Middle",
                         "mouseState": "Released"
@@ -65,6 +68,18 @@ class ItemActionsConfigTest {
                       "itemId": "RuneTale_Bones",
                       "skill": "unknown",
                       "xp": 5.0
+                    }
+                  ],
+                  "placementDespawnRules": [
+                    {
+                      "id": "placed_logs",
+                      "targetBlockIds": [
+                        "RuneTale_Log"
+                      ],
+                      "delayMillis": 30000,
+                      "applyMode": "SET_BLOCK",
+                      "setBlockId": "Empty",
+                      "requireTargetBlockMatch": true
                     }
                   ],
                   "debug": {
@@ -92,6 +107,16 @@ class ItemActionsConfigTest {
         assertThat(action.replaceTargetBlockId()).isEqualTo("Furniture_Crude_Brazier");
         assertThat(action.replaceTargetBlockDelayMillis()).isEqualTo(1200L);
         assertThat(action.requireTargetBlockMatchForReplacement()).isFalse();
+        assertThat(action.despawnDelayMillis()).isEqualTo(30000L);
+        assertThat(action.despawnApplyMode()).isEqualTo(ItemActionsConfig.BlockApplyMode.NATURAL_REMOVE);
+        assertThat(action.requireTargetBlockMatchForDespawn()).isFalse();
+        assertThat(config.placementDespawnRules()).hasSize(1);
+        ItemActionsConfig.PlacementDespawnRule placementRule = config.placementDespawnRules().getFirst();
+        assertThat(placementRule.id()).isEqualTo("placed_logs");
+        assertThat(placementRule.delayMillis()).isEqualTo(30000L);
+        assertThat(placementRule.applyMode()).isEqualTo(ItemActionsConfig.BlockApplyMode.SET_BLOCK);
+        assertThat(placementRule.setBlockId()).isEqualTo("Empty");
+        assertThat(placementRule.matchesTargetBlockId("RuneTale_Log")).isTrue();
         assertThat(config.debugPluginKey()).isEqualTo("skills-prayer");
     }
 


### PR DESCRIPTION
Keep firemaking objects from lingering by resetting 30s timers on use, naturally despawning fires with drops, and letting placed logs vanish to Empty.
